### PR TITLE
Add Better Questing as Book Alias

### DIFF
--- a/src/main/java/vazkii/akashictome/ConfigHandler.java
+++ b/src/main/java/vazkii/akashictome/ConfigHandler.java
@@ -93,7 +93,8 @@ public class ConfigHandler {
                 "animus=bloodmagic",
                 "integrateddynamics=integratedtunnels",
                 "mekanismgenerators=mekanism",
-                "mekanismtools=mekanism");
+                "mekanismtools=mekanism",
+                "questbook=betterquesting");
 
         for (String s : aliasesList) if (s.matches(".+?=.+")) {
             String[] tokens = s.toLowerCase().split("=");


### PR DESCRIPTION
Just cosmetic, so it shows the Better Questing mod as the origin of the questbook instead of Standard Expansion.