### PR TITLE
Use Registry Names instead of IDs when saving NBT

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    api("com.github.GTNewHorizons:NotEnoughItems:2.6.34-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.6.44-GTNH:dev")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.26'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
 }
 
 

--- a/src/main/java/vazkii/akashictome/AkashicTome.java
+++ b/src/main/java/vazkii/akashictome/AkashicTome.java
@@ -11,7 +11,8 @@ import vazkii.akashictome.proxy.CommonProxy;
         name = "Akashic Tome",
         version = AkashicVersion.VERSION,
         dependencies = "after:NotEnoughItems",
-        guiFactory = "vazkii.akashictome.client.GuiFactory")
+        guiFactory = "vazkii.akashictome.client.GuiFactory",
+        acceptedMinecraftVersions = "[1.7.10]")
 public class AkashicTome {
 
     public static final String MOD_ID = "akashictome";

--- a/src/main/java/vazkii/akashictome/AttachementRecipe.java
+++ b/src/main/java/vazkii/akashictome/AttachementRecipe.java
@@ -79,9 +79,7 @@ public class AttachementRecipe implements IRecipe {
         }
 
         ItemNBTHelper.setString(target, MorphingHandler.TAG_ITEM_DEFINED_MOD, mod);
-        NBTTagCompound modCmp = new NBTTagCompound();
-        target.writeToNBT(modCmp);
-        morphData.setTag(mod, modCmp);
+        morphData.setTag(mod, ItemNBTHelper.saveItemStackToNBT(target));
 
         return copy;
     }

--- a/src/main/java/vazkii/akashictome/ItemTome.java
+++ b/src/main/java/vazkii/akashictome/ItemTome.java
@@ -14,6 +14,7 @@ import net.minecraftforge.oredict.RecipeSorter;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import vazkii.akashictome.item.ItemMod;
+import vazkii.akashictome.utils.ItemNBTHelper;
 
 public class ItemTome extends ItemMod {
 
@@ -66,7 +67,7 @@ public class ItemTome extends ItemMod {
             for (String s : keys) {
                 NBTTagCompound cmp = data.getCompoundTag(s);
                 if (cmp != null) {
-                    ItemStack modStack = ItemStack.loadItemStackFromNBT(cmp);
+                    ItemStack modStack = ItemNBTHelper.loadItemStackFromNBT(cmp);
                     if (modStack != null) {
                         String name = modStack.getDisplayName();
                         if (modStack.hasTagCompound()

--- a/src/main/java/vazkii/akashictome/MorphingHandler.java
+++ b/src/main/java/vazkii/akashictome/MorphingHandler.java
@@ -129,7 +129,7 @@ public final class MorphingHandler {
             for (String s : keys) {
                 NBTTagCompound cmp = data.getCompoundTag(s);
                 if (cmp != null) {
-                    ItemStack modStack = ItemStack.loadItemStackFromNBT(cmp);
+                    ItemStack modStack = ItemNBTHelper.loadItemStackFromNBT(cmp);
                     stacks.add(modStack);
                 }
             }
@@ -140,9 +140,7 @@ public final class MorphingHandler {
     public static ItemStack makeMorphedStack(ItemStack currentStack, String targetMod, NBTTagCompound morphData) {
         String currentMod = ItemNBTHelper.getString(currentStack, TAG_ITEM_DEFINED_MOD, getModFromStack(currentStack));
 
-        NBTTagCompound currentCmp = new NBTTagCompound();
-        currentStack.writeToNBT(currentCmp);
-        currentCmp = (NBTTagCompound) currentCmp.copy();
+        NBTTagCompound currentCmp = ItemNBTHelper.saveItemStackToNBT(currentStack);
         if (currentCmp.hasKey("tag")) currentCmp.getCompoundTag("tag").removeTag(TAG_TOME_DATA);
 
         if (!currentMod.equalsIgnoreCase(MINECRAFT) && !currentMod.equalsIgnoreCase(AkashicTome.MOD_ID))
@@ -154,7 +152,7 @@ public final class MorphingHandler {
             NBTTagCompound targetCmp = morphData.getCompoundTag(targetMod);
             morphData.removeTag(targetMod);
 
-            stack = ItemStack.loadItemStackFromNBT(targetCmp);
+            stack = ItemNBTHelper.loadItemStackFromNBT(targetCmp);
             if (stack == null) stack = new ItemStack(ModItems.tome);
         }
 

--- a/src/main/java/vazkii/akashictome/client/GuiFactory.java
+++ b/src/main/java/vazkii/akashictome/client/GuiFactory.java
@@ -39,7 +39,7 @@ public class GuiFactory implements IModGuiFactory {
         public ConfigGui(GuiScreen parentScreen) {
             super(
                     parentScreen,
-                    new ConfigElement(ConfigHandler.config.getCategory(Configuration.CATEGORY_GENERAL))
+                    new ConfigElement<>(ConfigHandler.config.getCategory(Configuration.CATEGORY_GENERAL))
                             .getChildElements(),
                     AkashicTome.MOD_ID,
                     false,

--- a/src/main/java/vazkii/akashictome/client/GuiTome.java
+++ b/src/main/java/vazkii/akashictome/client/GuiTome.java
@@ -49,7 +49,7 @@ public class GuiTome extends GuiScreen {
             for (String s : keys) {
                 NBTTagCompound cmp = data.getCompoundTag(s);
                 if (cmp != null) {
-                    ItemStack modStack = ItemStack.loadItemStackFromNBT(cmp);
+                    ItemStack modStack = ItemNBTHelper.loadItemStackFromNBT(cmp);
                     stacks.add(modStack);
                 }
             }

--- a/src/main/java/vazkii/akashictome/utils/ItemNBTHelper.java
+++ b/src/main/java/vazkii/akashictome/utils/ItemNBTHelper.java
@@ -5,13 +5,16 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.oredict.OreDictionary;
 
 import codechicken.nei.PositionedStack;
+import cpw.mods.fml.common.registry.GameData;
 
 public final class ItemNBTHelper {
 
@@ -228,5 +231,42 @@ public final class ItemNBTHelper {
         for (ItemStack item : stack.items) if (areStacksSameTypeCraftingWithNBT(item, ingredient)) return true;
 
         return false;
+    }
+
+    /**
+     * Alternative to {@link ItemStack#loadItemStackFromNBT(NBTTagCompound)} which uses the item's registry name instead
+     * of its ID.
+     */
+    public static ItemStack loadItemStackFromNBT(NBTTagCompound nbt) {
+        String name = nbt.getString("name");
+        if (name == null) {
+            return null;
+        }
+        Item item = GameData.getItemRegistry().getObject(name);
+        if (item == null) {
+            return null;
+        }
+        int size = nbt.getByte("Count");
+        int meta = nbt.getShort("Damage");
+        ItemStack stack = new ItemStack(item, size, meta);
+        if (nbt.hasKey("tag", NBT.TAG_COMPOUND)) {
+            stack.stackTagCompound = nbt.getCompoundTag("tag");
+        }
+        return stack;
+    }
+
+    /**
+     * Alternative to {@link ItemStack#writeToNBT(NBTTagCompound)} which uses the item's registry name instead of its
+     * ID.
+     */
+    public static NBTTagCompound saveItemStackToNBT(ItemStack stack) {
+        NBTTagCompound nbt = new NBTTagCompound();
+        nbt.setString("name", stack.getItem().delegate.name());
+        nbt.setByte("Count", (byte) stack.stackSize);
+        nbt.setShort("Damage", (short) stack.getItemDamage());
+        if (stack.stackTagCompound != null) {
+            nbt.setTag("tag", stack.stackTagCompound);
+        }
+        return nbt;
     }
 }


### PR DESCRIPTION
Using the vanilla methods `ItemStack#loadItemStackFromNBT(NBTTagCompound)` and `ItemStack#writeToNBT(NBTTagCompound)` is problematic because they use item IDs. These change from world to world. While this is not problematic when saving a world, it can be e.g. when awarding the Tome with included NBT as quest reward. The NBT specified when configuring the reward may only be correct for the world it was created in, in other worlds these IDs may refer to different items. This is what happend [here](https://discord.com/channels/181078474394566657/522098956491030558/1299068091229147249).

**Note: This is a breaking change! Books previously put in the tome will vanish!**