### PR TITLE
Fix incorrect OpenComputers Manual ID in the whitelist

### DIFF
--- a/src/main/java/vazkii/akashictome/ConfigHandler.java
+++ b/src/main/java/vazkii/akashictome/ConfigHandler.java
@@ -38,7 +38,7 @@ public class ConfigHandler {
         whitelistedItems = loadPropStringList(
                 "Whitelisted Items",
                 "roots:runedtablet",
-                "opencomputers:tool:4",
+                "OpenComputers:item:98",
                 "immersiveengineering:tool:3",
                 "integrateddynamics:on_the_dynamics_of_integration",
                 "theoneprobe:probenote",


### PR DESCRIPTION
Fixes [#19040](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19040) from the modpack repo